### PR TITLE
[Update] MCP2210のライブラリをフォーク先に切り替え

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "MCP2210-Library"]
 	path = MCP2210-Library
-	url = https://github.com/kerrydwong/MCP2210-Library.git
+	url = https://github.com/TaiyouKomazawa/MCP2210-Library.git


### PR DESCRIPTION
データを読み込んだまま戻ってこなくなるバグがあったので修正した。
ライブラリは長くメンテナンスされていないためフォークした。